### PR TITLE
Update binding method

### DIFF
--- a/src/OnboardServiceProvider.php
+++ b/src/OnboardServiceProvider.php
@@ -12,6 +12,6 @@ class OnboardServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-onboard');
 
-        $this->app->scoped(OnboardingSteps::class);
+        $this->app->singleton(OnboardingSteps::class);
     }
 }


### PR DESCRIPTION
Registering the instance using the scoped methods causes the instance to be flushed when using a queue worker.

For example, the code User::find(1)->onboarding()->steps()->count() inside a queued job will always return return 0, even when onboarding steps exist.

This PR fixes that issue.