### PR TITLE
Add callable attributes support

### DIFF
--- a/src/OnboardingSteps.php
+++ b/src/OnboardingSteps.php
@@ -20,7 +20,7 @@ class OnboardingSteps
     public function steps(Onboardable $model): Collection
     {
         return collect($this->steps)
-            ->map(fn (OnboardingStep $step) => $step->setModel($model))
+            ->map(fn (OnboardingStep $step) => $step->initiate($model))
             ->filter(fn (OnboardingStep $step) => $step->notExcluded());
     }
 }

--- a/tests/OnboardTest.php
+++ b/tests/OnboardTest.php
@@ -181,3 +181,26 @@ it('will only run complete callbacks once', function () {
     expect($called)->toBe(1)
         ->and($onboarding->finished())->toBeFalse();
 });
+
+test('step attrbiutes can be callable', function () {
+    $this->user->name = fake()->name;
+
+    $onboardingSteps = new OnboardingSteps();
+    $onboardingSteps->addStep('Step 1')
+        ->link('/some/url')
+        ->cta('Test This!')
+        ->attributes(function (User $model) {
+            return [
+                'user_name' => $model->name,
+            ];
+        });
+
+    $onboarding = new OnboardingManager($this->user, $onboardingSteps);
+
+    $step = $onboarding->steps()->first();
+
+    expect($step)
+        ->user_name->not->toBeNull()
+        ->user_name->toBe($this->user->name)
+        ->title->tobe('Step 1');
+});


### PR DESCRIPTION
This PR adds support for callable attributes. 

```php
Onboard::addStep('Payments')
    ->cta('Complete')
    ->attributes(function (User $model) {
            return [
                'link' => $model->stripeOnboarding(),
            ];
    });
```

#### My use case
I came across a need for it on a project I am currently working on; one of the attributes (link, in my case) is a Stripe onboarding link (returned from a model method). Therefore, I can not simply use the ```route()``` helper or static address.