### PR TITLE
Allow steps to be limited to specific classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,41 @@ Onboard::addStep('Excluded Step')
     });
 ```
 
+Limiting steps to a specific class:
+    
+```php
+Onboard::addStep('Limited Step', User::class)
+    ->link('/post/create');
+
+// or
+
+Onboard::addStep('Limited Step', 'App\Models\User')
+    ->link('/post/create');
+```
+
+When using limited steps, steps that are not limited will be available to all classes. For example:
+
+```php
+// Defining User steps
+Onboard::addStep('Limited User Step', User::class)
+    ->link('/post/create');
+
+// Defining Team steps
+Onboard::addStep('Limited Team Step', Team::class)
+    ->link('/post/create');
+
+// Defining a step that is available to all classes
+Onboard::addStep('Normal Step')
+    ->link('/post/create');
+```
+
+The above will result in 1 step being available to all classes, and 2 steps being available to the `User` and `Team` classes:
+
+`Other` classes will only see the `Normal Step`.
+`User` classes will both see the `Normal Step` and `Limited User Step`.
+`Team` classes will both see the `Normal Step` and `Limited Team Step`.
+
+
 Definining custom attributes and accessing them:
 
 ```php

--- a/src/Facades/Onboard.php
+++ b/src/Facades/Onboard.php
@@ -9,7 +9,7 @@ use Spatie\Onboard\OnboardingStep;
 use Spatie\Onboard\OnboardingSteps;
 
 /**
- * @method OnboardingStep addStep(string $title)
+ * @method OnboardingStep addStep(string $title, string $model = null)
  * @method Collection<OnboardingStep> steps(Onboardable $model)
  */
 class Onboard extends Facade

--- a/src/OnboardingSteps.php
+++ b/src/OnboardingSteps.php
@@ -10,17 +10,37 @@ class OnboardingSteps
     /** @var array<OnboardingStep> */
     protected array $steps = [];
 
-    public function addStep(string $title): OnboardingStep
+    public function addStep(string $title, string $model = null): OnboardingStep
     {
-        $this->steps[] = $step = new OnboardingStep($title);
+        $step = new OnboardingStep($title);
+
+        if ($model && new $model() instanceof Onboardable) {
+            $this->steps[$model][] = $step;
+        } else {
+            $this->steps['default'][] = $step;
+        }
 
         return $step;
     }
 
     public function steps(Onboardable $model): Collection
     {
-        return collect($this->steps)
+        return collect($this->getStepsArray($model))
             ->map(fn (OnboardingStep $step) => $step->initiate($model))
             ->filter(fn (OnboardingStep $step) => $step->notExcluded());
+    }
+
+    private function getStepsArray(Onboardable $model): array
+    {
+        $key = get_class($model);
+
+        if (key_exists($key, $this->steps)) {
+            return array_merge(
+                $this->steps[$key],
+                $this->steps['default'] ?? []
+            );
+        }
+
+        return $this->steps['default'] ?? [];
     }
 }

--- a/tests/Team.php
+++ b/tests/Team.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\Onboard\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Onboard\Concerns\GetsOnboarded;
+use Spatie\Onboard\Concerns\Onboardable;
+
+class Team extends Model implements Onboardable
+{
+    use GetsOnboarded;
+}


### PR DESCRIPTION
This PR aims to allow steps to be limited to specific classes which allows you to setup steps for multiple models for example if you have steps for users and teams.

Example Usage:
```php
// Defining User steps
Onboard::addStep('Limited User Step', User::class)
    ->link('/post/create');

// Defining Team steps
Onboard::addStep('Limited Team Step', Team::class)
    ->link('/post/create');

// Defining a step that is available to all classes
Onboard::addStep('Normal Step')
    ->link('/post/create');
```

The above will result in 1 step being available to all classes, and 2 steps being available to the `User` and `Team` classes:

`Other` classes will only see the `Normal Step`.
`User` classes will both see the `Normal Step` and `Limited User Step`.
`Team` classes will both see the `Normal Step` and `Limited Team Step`.


This should be a non breaking change as you are still able to define steps the same as before. Also, when you specify a class, it will merge the class steps and non-class specific steps as seen in the example above.

Solves: [#8](https://github.com/spatie/laravel-onboard/discussions/8_)