### PR TITLE
fix wrong variable name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ use Spatie\Onboard\Facades\Onboard;
 Onboard::addStep('Complete Profile')
     ->link('/profile')
     ->cta('Complete')
-    ->completeIf(function (User $user) {
-        return $user->profile->isComplete();
+    ->completeIf(function (User $model) {
+        return $model->profile->isComplete();
     });
 
 Onboard::addStep('Create Your First Post')
     ->link('/post/create')
     ->cta('Create Post')
-    ->completeIf(function (User $user) {
-        return $user->posts->count() > 0;
+    ->completeIf(function (User $model) {
+        return $model->posts->count() > 0;
     });
 ```
 


### PR DESCRIPTION
This PR fixes a wrong variable name in your documentation. We discovered this since `$user` did not work while `$model` is working in our implementation. Also you are using `$model` below of the first example, so I assumed it's wrong.