### PR TITLE
Remove carbon dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": "^8.0|^8.1",
         "illuminate/contracts": "^9.0",
-        "nesbot/carbon": "^2.63",
         "spatie/laravel-package-tools": "^1.9.2",
         "spatie/once": "^3.1"
     },


### PR DESCRIPTION
This PR removes the `nesbot/carbon` dependency accidentally added in #22 as it is not required.